### PR TITLE
healthcheck route now prefixed with /api/v1

### DIFF
--- a/app/src/app.js
+++ b/app/src/app.js
@@ -4,10 +4,7 @@ const koaLogger = require("koa-logger");
 const config = require("config");
 const loader = require("loader");
 const mongoose = require("mongoose");
-const koaSimpleHealthCheck = require("koa-simple-healthcheck");
 const loggedInUserService = require("./services/LoggedInUserService");
-
-console.log(config)
 
 mongoose.Promise = Promise;
 const ErrorSerializer = require("serializers/error.serializer");
@@ -65,7 +62,6 @@ app.use(async (ctx, next) => {
 });
 
 app.use(koaLogger());
-app.use(koaSimpleHealthCheck());
 
 app.use(async function (ctx, next) {
   await loggedInUserService.setLoggedInUser(ctx, logger);

--- a/app/src/routes/api/v1/heathcheck.router.js
+++ b/app/src/routes/api/v1/heathcheck.router.js
@@ -1,0 +1,10 @@
+const Router = require("koa-router");
+const koaSimpleHealthCheck = require("koa-simple-healthcheck");
+
+const router = new Router({
+  prefix: "/healthcheck"
+});
+
+router.get("/", koaSimpleHealthCheck());
+
+module.exports = router;

--- a/app/test/e2e/health-check.spec.js
+++ b/app/test/e2e/health-check.spec.js
@@ -6,7 +6,7 @@ chai.should();
 
 let requester;
 
-describe("GET healthcheck", function () {
+describe("GET /api/v1/healthcheck", function () {
   // eslint-disable-next-line mocha/no-hooks-for-single-case
   before(async function () {
     if (process.env.NODE_ENV !== "test") {
@@ -19,7 +19,7 @@ describe("GET healthcheck", function () {
   });
 
   it("Checking the application's health should return a 200", async function () {
-    const response = await requester.get("/healthcheck");
+    const response = await requester.get("/api/v1/healthcheck");
 
     response.status.should.equal(200);
     response.body.should.be.an("object").and.have.property("uptime");


### PR DESCRIPTION
George requires the healthcheck route to now be prefixed with `/api/v1`

The healthcheck plugin can be passed a "path" key to change the route, see below:

```JavaScript
app.use(require('koa-simple-healthcheck')({
    path: '/ping',
    healthy: function () {
        return { everything: 'is ok' };
    },
}))
```

But I wanted to follow the design patten used in the rest of the app.

So moved the healthcheck plugin to `routes/api/v1` folder so that `app/loader.js` will prefix the route by the folder structure automatically.

Tests pass as before.