### PR TITLE
mongodb now initialises with an authorised user

### DIFF
--- a/app/src/app.js
+++ b/app/src/app.js
@@ -9,9 +9,6 @@ const loggedInUserService = require("./services/LoggedInUserService");
 mongoose.Promise = Promise;
 const ErrorSerializer = require("serializers/error.serializer");
 
-const mongoUri = `mongodb://${config.get("mongodb.host")}:${config.get("mongodb.port")}/${config.get(
-  "mongodb.database"
-)}`;
 const validate = require("koa-validate");
 
 const koaBody = require("koa-body")({
@@ -21,6 +18,17 @@ const koaBody = require("koa-body")({
   textLimit: "50mb"
 });
 
+let dbSecret = config.get("mongodb.secret");
+if (typeof dbSecret === "string") {
+  dbSecret = JSON.parse(dbSecret);
+}
+
+const mongoURL =
+  "mongodb://" +
+  `${dbSecret.username}:${dbSecret.password}` +
+  `@${config.get("mongodb.host")}:${config.get("mongodb.port")}` +
+  `/${config.get("mongodb.database")}`;
+
 const onDbReady = err => {
   if (err) {
     logger.error(err);
@@ -28,7 +36,7 @@ const onDbReady = err => {
   }
 };
 
-mongoose.connect(mongoUri, onDbReady);
+mongoose.connect(mongoURL, onDbReady);
 
 const app = new Koa();
 

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -10,7 +10,9 @@
   },
   "mongodb": {
     "host": "MONGODB_HOST",
-    "port": "MONGODB_PORT"
+    "port": "MONGODB_PORT",
+    "secret": "DB_SECRET",
+    "database": "DB_DATABASE"
   },
   "jwt": {
     "token": "JWT_SECRET"

--- a/data/mongo/001_users.js
+++ b/data/mongo/001_users.js
@@ -1,0 +1,10 @@
+db.createUser({
+  user: "admin",
+  pwd: "password",
+  roles: [
+    {
+      role: "readWrite",
+      db: "fw_teams_db"
+    }
+  ]
+});

--- a/docker-compose-develop.yml
+++ b/docker-compose-develop.yml
@@ -14,6 +14,8 @@ services:
       JWT_SECRET: reallyunguessablesecretkey
       MONGODB_HOST: mongo
       MONGODB_PORT: 27017
+      DB_SECRET: '{ "username": "admin", "password": "password" }'
+      DB_DATABASE: fw_teams_db
       REDIS_URL: redis://redis:6379
       REDIS_QUEUE_NAME: mail
       APP_URL: http://127.0.0.1:3035
@@ -34,8 +36,13 @@ services:
     container_name: fw-teams-mongo-develop
     ports:
       - "27022:27017"
+    environment:
+      MONGO_INITDB_DATABASE: fw_teams_db
+      MONGO_INITDB_ROOT_PASSWORD: password
+      MONGO_INITDB_ROOT_USERNAME: admin
     volumes:
-      - $HOME/docker/data/fw-teams/mongodb:/data/db
+      - ./data/mongo/001_users.js:/docker-entrypoint-initdb.d/001_users.js:ro
+      - fw-teams-mongodb-data:/data/db
     restart: always
     networks:
       - gfw-network
@@ -48,6 +55,10 @@ services:
       - ALLOW_EMPTY_PASSWORD=yes
     networks:
       - gfw-teams-network
+
+volumes:
+  fw-teams-mongodb-data:
+
 networks:
   gfw-teams-network:
     name: gfw-teams-network

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -14,6 +14,8 @@ services:
       JWT_SECRET: reallyunguessablesecretkey
       MONGODB_HOST: mongo
       MONGODB_PORT: 27017
+      DB_SECRET: '{ "username": "admin", "password": "password" }'
+      DB_DATABASE: fw_teams_db
       REDIS_URL: redis://redis:6379
       REDIS_QUEUE_NAME: mail
       APP_URL: http://127.0.0.1:3035
@@ -29,6 +31,13 @@ services:
     command: --smallfiles
     ports:
       - "27017"
+    environment:
+      MONGO_INITDB_DATABASE: fw_teams_db
+      MONGO_INITDB_ROOT_PASSWORD: password
+      MONGO_INITDB_ROOT_USERNAME: admin
+    volumes:
+      - ./data/mongo/001_users.js:/docker-entrypoint-initdb.d/001_users.js:ro
+      - fw-teams-mongodb-data:/data/db
 
   redis:
     image: bitnami/redis
@@ -36,3 +45,6 @@ services:
       - "6379"
     environment:
       - ALLOW_EMPTY_PASSWORD=yes
+
+volumes:
+  fw-teams-mongodb-data:

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -50,9 +50,9 @@ module "fargate_autoscaling" {
   lb_target_group_arn = module.fargate_autoscaling.lb_target_group_arn
   listener_arn        = data.terraform_remote_state.fw_core.outputs.lb_listener_arn
   project_prefix      = var.project_prefix
-  path_pattern        = ["/api/v1/fw_teams/healthcheck", "/api/v1/teams*"]
+  path_pattern        = ["/v1/fw_teams/healthcheck", "/v1/teams*"]
   priority            = 4
-  health_check_path = "/api/v1/fw_teams/healthcheck"
+  health_check_path = "/v1/fw_teams/healthcheck"
 
   depends_on = [
     module.app_docker_image

--- a/terraform/templates/container_definition.json.tmpl
+++ b/terraform/templates/container_definition.json.tmpl
@@ -59,6 +59,10 @@
   ],
   "secrets": [
     {
+      "name": "DB_SECRET",
+      "valueFrom": "${db_secret_arn}"
+    },
+    {
       "name": "GFW_DATA_API_KEY",
       "valueFrom": "${gfw_data_api_key}"
     }


### PR DESCRIPTION
Now locally when the MongoDB is initialised an admin user is created, following the technique described https://github.com/docker-library/mongo/issues/174#issuecomment-449984230 and [here](https://dev.to/emmysteven/how-not-to-configure-mongodb-on-docker-nbn). This is to mimic the behaviour on production.

The local MongoDB data is now sorted in a named volume so it's easier to work with locally! e.g. docker volume rm gfw-forms-mongodb-data

DB_SECRET is now provided by terraform in dev, staging and production environments, although this wasn't used in the code base.

Locally this is now replicated. Once DB_SECRET in parsed the database's "username" and "password" key value pairs are available locally and in production. 