### PR TITLE
loader fix for es modules

### DIFF
--- a/app/src/loader.js
+++ b/app/src/loader.js
@@ -20,8 +20,8 @@ module.exports = (() => {
       const newPath = path ? `${path}/${file}` : file;
       const stat = fs.statSync(newPath);
       if (!stat.isDirectory()) {
-        if (file.lastIndexOf(".router.js") !== -1) {
-          if (file === "index.router.js") {
+        if (file.lastIndexOf(".router.js") !== -1 || file.lastIndexOf(".router.ts") !== -1) {
+          if (file === "index.router.ts" || file === "index.router.ts") {
             existIndexRouter = true;
           } else {
             logger.debug("Loading route %s, in path %s", newPath, pathApi);
@@ -40,7 +40,7 @@ module.exports = (() => {
     });
     if (existIndexRouter) {
       // load indexRouter when finish other Router
-      const newPath = path ? `${path}/indexRouter.js` : "indexRouter.js";
+      const newPath = path ? `${path}/index.router` : "index.router";
       logger.debug("Loading route %s, in path %s", newPath, pathApi);
       if (pathApi) {
         app.use(mount(pathApi, requireESModuleDefault(newPath).middleware()));

--- a/app/src/loader.js
+++ b/app/src/loader.js
@@ -4,6 +4,12 @@ const routersPath = `${__dirname}/routes`;
 const logger = require("logger");
 const mount = require("koa-mount");
 
+const requireESModuleDefault = path => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const module = require(path);
+  return module.__esModule ? module.default : module;
+};
+
 /**
  * Load routers
  */
@@ -21,9 +27,9 @@ module.exports = (() => {
           } else {
             logger.debug("Loading route %s, in path %s", newPath, pathApi);
             if (pathApi) {
-              app.use(mount(pathApi, require(newPath).middleware()));
+              app.use(mount(pathApi, requireESModuleDefault(newPath).middleware()));
             } else {
-              app.use(require(newPath).middleware());
+              app.use(requireESModuleDefault(newPath).middleware());
             }
           }
         }
@@ -38,9 +44,9 @@ module.exports = (() => {
       const newPath = path ? `${path}/indexRouter.js` : "indexRouter.js";
       logger.debug("Loading route %s, in path %s", newPath, pathApi);
       if (pathApi) {
-        app.use(mount(pathApi, require(newPath).middleware()));
+        app.use(mount(pathApi, requireESModuleDefault(newPath).middleware()));
       } else {
-        app.use(require(newPath).middleware());
+        app.use(requireESModuleDefault(newPath).middleware());
       }
     }
   };

--- a/app/src/loader.js
+++ b/app/src/loader.js
@@ -5,7 +5,6 @@ const logger = require("logger");
 const mount = require("koa-mount");
 
 const requireESModuleDefault = path => {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
   const module = require(path);
   return module.__esModule ? module.default : module;
 };


### PR DESCRIPTION
TS files will compile to ES Modules.
The `loader` script can't load ES Modules without doing `require("...").default` first.
Added a function to check for ES Module flag and return the .default instead.