### PR TITLE
Hotfix/invitation not sending twice

### DIFF
--- a/app/src/routes/v1/team.router.js
+++ b/app/src/routes/v1/team.router.js
@@ -40,7 +40,6 @@ class TeamRouter {
         TeamService.deleteConfirmedUserFromPreviousTeams(userId);
         team.users = team.users.filter(user => user !== email);
         team.confirmedUsers = team.confirmedUsers.concat({ id: userId, email });
-        team.sentInvitations = team.sentInvitations.filter(sentEmail => sentEmail !== email);
         TeamService.sendManagerConfirmation(email, team.managers, ctx.request.body.locale);
         await team.save();
       }
@@ -109,13 +108,6 @@ class TeamRouter {
     if (body.users) {
       logger.info(`Users ${body.users}`);
       team.users = body.users.filter(user => user !== userId);
-
-      // Only allow sentInvitations array to contain email addresses of current
-      // users on the team. This means if a user is removed from the team and
-      // then added again the invitation email will be resent.
-      team.sentInvitations = team.sentInvitations.filter(sentEmailAddress => {
-        return team.users.some(userEmail => userEmail === sentEmailAddress);
-      });
     }
     if (body.confirmedUsers) {
       logger.info(`Users ${body.confirmedUsers}`);

--- a/app/src/routes/v1/team.router.js
+++ b/app/src/routes/v1/team.router.js
@@ -105,9 +105,20 @@ class TeamRouter {
       }
       team.managers = body.managers;
     }
+
+    let newUsers = [];
     if (body.users) {
       logger.info(`Users ${body.users}`);
-      team.users = body.users.filter(user => user !== userId);
+
+      const validUsers = body.users.filter(user => user !== userId);
+
+      newUsers = validUsers.filter(bodyUserEmail => {
+        return !team.users.includes(bodyUserEmail);
+      });
+
+      logger.info(`New users ${newUsers}`);
+
+      team.users = validUsers;
     }
     if (body.confirmedUsers) {
       logger.info(`Users ${body.confirmedUsers}`);
@@ -123,7 +134,7 @@ class TeamRouter {
     }
 
     await team.save();
-    TeamService.sendNotifications(body.users, team, locale);
+    TeamService.sendNotifications(newUsers, team, locale);
     ctx.body = TeamSerializer.serialize(team);
   }
 

--- a/app/src/routes/v1/team.router.js
+++ b/app/src/routes/v1/team.router.js
@@ -40,6 +40,7 @@ class TeamRouter {
         TeamService.deleteConfirmedUserFromPreviousTeams(userId);
         team.users = team.users.filter(user => user !== email);
         team.confirmedUsers = team.confirmedUsers.concat({ id: userId, email });
+        team.sentInvitations = team.sentInvitations.filter(sentEmail => sentEmail !== email);
         TeamService.sendManagerConfirmation(email, team.managers, ctx.request.body.locale);
         await team.save();
       }
@@ -108,6 +109,13 @@ class TeamRouter {
     if (body.users) {
       logger.info(`Users ${body.users}`);
       team.users = body.users.filter(user => user !== userId);
+
+      // Only allow sentInvitations array to contain email addresses of current
+      // users on the team. This means if a user is removed from the team and
+      // then added again the invitation email will be resent.
+      team.sentInvitations = team.sentInvitations.filter(email => {
+        return team.users.some(user => user.email === email);
+      });
     }
     if (body.confirmedUsers) {
       logger.info(`Users ${body.confirmedUsers}`);

--- a/app/src/routes/v1/team.router.js
+++ b/app/src/routes/v1/team.router.js
@@ -113,8 +113,8 @@ class TeamRouter {
       // Only allow sentInvitations array to contain email addresses of current
       // users on the team. This means if a user is removed from the team and
       // then added again the invitation email will be resent.
-      team.sentInvitations = team.sentInvitations.filter(email => {
-        return team.users.some(user => user.email === email);
+      team.sentInvitations = team.sentInvitations.filter(sentEmailAddress => {
+        return team.users.some(userEmail => userEmail === sentEmailAddress);
       });
     }
     if (body.confirmedUsers) {

--- a/app/src/services/team.service.js
+++ b/app/src/services/team.service.js
@@ -28,7 +28,7 @@ class TeamService {
         "application.url"
       )}/settings?confirmToken=${generatedToken}&confirmToken=${generatedToken}`;
 
-      logger.info(`Sent team invitation to: ${email}`)
+      logger.info(`Sent team invitation to: ${email}`);
       const invitationMailId = `team-invitation-${locale || "en"}`;
       MailService.sendMail(invitationMailId, { link }, [{ address: { email } }]);
     });

--- a/app/src/services/team.service.js
+++ b/app/src/services/team.service.js
@@ -27,12 +27,10 @@ class TeamService {
       const link = `${config.get("application.url")}/login?callbackUrl=${config.get(
         "application.url"
       )}/settings?confirmToken=${generatedToken}&confirmToken=${generatedToken}`;
-      if (!team.sentInvitations.includes(email)) {
-        const invitationMailId = `team-invitation-${locale || "en"}`;
-        MailService.sendMail(invitationMailId, { link }, [{ address: { email } }]);
-        team.sentInvitations = team.sentInvitations.concat(email);
-        await team.save();
-      }
+
+      logger.info(`Sent team invitation to: ${email}`)
+      const invitationMailId = `team-invitation-${locale || "en"}`;
+      MailService.sendMail(invitationMailId, { link }, [{ address: { email } }]);
     });
   }
 


### PR DESCRIPTION
This has already been merged into Staging !

Invitation emails are now sent for every new user added to team.

Before if an email address was added their email was never removed from the sentInvitation array. Meaning if they were removed and then added again they wouldn't receive their new invitation!

Now when a new team is created all the users are emailed and when a team is updated all new users are emailed.