### PR TITLE
Administrator key added to teams

### DIFF
--- a/app/src/models/team.model.ts
+++ b/app/src/models/team.model.ts
@@ -11,7 +11,7 @@ export enum EUserRole {
 export interface ITeam {
   name?: string;
   userRole?: EUserRole;
-  administrator: typeof Schema.Types.ObjectId;
+  administrator: string;
   // Managers of the Team
   managers: { id: string; email?: string }[];
   // Users who have been invited but have not confirmed their invitation

--- a/app/src/models/team.model.ts
+++ b/app/src/models/team.model.ts
@@ -11,6 +11,7 @@ export enum EUserRole {
 export interface ITeam {
   name?: string;
   userRole?: EUserRole;
+  administrator: typeof Schema.Types.ObjectId;
   // Managers of the Team
   managers: { id: string; email?: string }[];
   // Users who have been invited but have not confirmed their invitation
@@ -26,6 +27,7 @@ export interface ITeam {
 
 const TeamSchema = new Schema({
   name: { type: String, required: false, trim: true },
+  administrator: { type: Schema.Types.ObjectId },
   managers: { type: Array, default: [] },
   users: { type: Array, default: [] },
   sentInvitations: { type: Array, default: [] },

--- a/app/src/routes/v3/leaveTeam.test.ts
+++ b/app/src/routes/v3/leaveTeam.test.ts
@@ -1,4 +1,5 @@
 import request from "supertest";
+import mongoose from "mongoose";
 import { TeamModel, ITeam, ITeamModel } from "models/team.model";
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
@@ -7,13 +8,16 @@ import loggedInUserService from "services/LoggedInUserService";
 // @ts-ignore
 import server from "app";
 
+const { ObjectId } = mongoose.Types;
+
 type TTeamDocument = Omit<ITeam, "createdAt">;
 
 const standardTeamDocument: TTeamDocument = {
   name: "test",
+  administrator: new ObjectId("123456789012345678901234"),
   confirmedUsers: [
     {
-      id: "1234TestAuthUser",
+      id: "addaddaddaddaddaddaddadd",
       email: "testAuthUser@test.com"
     },
     {
@@ -75,14 +79,14 @@ describe("PATCH /v3/teams/leave/:teamId", () => {
     expect(res.body.data.attributes.confirmedUsers).toEqual(
       expect.not.arrayContaining([
         {
-          id: "1234TestAuthUser",
+          id: "addaddaddaddaddaddaddadd",
           email: "testAuthUser@test.com"
         }
       ])
     );
   });
 
-  it("should remove 1234TestAuthUser from confirmed users array in the DB", async () => {
+  it("should remove addaddaddaddaddaddaddadd from confirmed users array in the DB", async () => {
     await exec();
 
     const updatedTeam = await TeamModel.findById(team._id);
@@ -90,19 +94,20 @@ describe("PATCH /v3/teams/leave/:teamId", () => {
     expect(updatedTeam.confirmedUsers).toEqual(
       expect.not.arrayContaining([
         {
-          id: "1234TestAuthUser",
+          id: "addaddaddaddaddaddaddadd",
           email: "testAuthUser@test.com"
         }
       ])
     );
   });
 
-  it("should return 400, when authorised user is the only manager of the team", async () => {
+  it("should return 400, when authorised user is the administrator of the team", async () => {
     teamDocument = {
       ...standardTeamDocument,
+      administrator: "addaddaddaddaddaddaddadd",
       managers: [
         {
-          id: "1234TestAuthUser",
+          id: "addaddaddaddaddaddaddadd",
           email: "testAuthUser@test.com"
         }
       ],
@@ -117,7 +122,7 @@ describe("PATCH /v3/teams/leave/:teamId", () => {
     const res = await exec();
 
     expect(res.status).toBe(400);
-    expect(res.body.errors[0].detail).toContain("only manager");
+    expect(res.body.errors[0].detail).toContain("administrator");
   });
 
   it("should return 400, when the authorised user isn't a member of the team", async () => {
@@ -142,12 +147,12 @@ describe("PATCH /v3/teams/leave/:teamId", () => {
     expect(res.status).toBe(400);
   });
 
-  it("should remove 1234TestAuthUser from managers array in the DB, when authorised user is not the only manager of the team", async () => {
+  it("should remove addaddaddaddaddaddaddadd from managers array in the DB, when authorised user is not the administrator", async () => {
     teamDocument = {
       ...standardTeamDocument,
       managers: [
         {
-          id: "1234TestAuthUser",
+          id: "addaddaddaddaddaddaddadd",
           email: "testAuthUser@test.com"
         },
         {
@@ -170,7 +175,7 @@ describe("PATCH /v3/teams/leave/:teamId", () => {
     expect(updatedTeam.managers).toEqual(
       expect.not.arrayContaining([
         {
-          id: "1234TestAuthUser",
+          id: "addaddaddaddaddaddaddadd",
           email: "testAuthUser@test.com"
         }
       ])

--- a/app/src/routes/v3/myTeams.test.ts
+++ b/app/src/routes/v3/myTeams.test.ts
@@ -3,6 +3,9 @@ import { TeamModel, ITeam } from "models/team.model";
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import server from "app";
+import mongoose from "mongoose";
+
+const { ObjectId } = mongoose.Types;
 
 interface ITeamResponse extends ITeam {
   id: string;
@@ -17,9 +20,10 @@ const standardTeamResponse: ITeamResponse = {
   areas: [],
   sentInvitations: [],
   users: [],
+  administrator: new ObjectId("addaddaddaddaddaddaddadd"),
   managers: [
     {
-      id: "1234TestAuthUser",
+      id: "addaddaddaddaddaddaddadd",
       email: "testAuthUser@test.com"
     }
   ]
@@ -79,8 +83,8 @@ describe("GET /v3/myteams", () => {
 
     expect(TeamModel.find).toHaveBeenLastCalledWith({
       $or: [
-        { "managers.id": "1234TestAuthUser" },
-        { "confirmedUsers.id": "1234TestAuthUser" },
+        { "managers.id": "addaddaddaddaddaddaddadd" },
+        { "confirmedUsers.id": "addaddaddaddaddaddaddadd" },
         { users: "testAuthUser@test.com" }
       ]
     });
@@ -90,7 +94,7 @@ describe("GET /v3/myteams", () => {
     await exec("?userRole=manager");
 
     expect(TeamModel.find).toHaveBeenLastCalledWith({
-      $or: [{ "managers.id": "1234TestAuthUser" }]
+      $or: [{ "managers.id": "addaddaddaddaddaddaddadd" }]
     });
   });
 
@@ -98,7 +102,7 @@ describe("GET /v3/myteams", () => {
     await exec("?userRole=monitor,invited");
 
     expect(TeamModel.find).toHaveBeenLastCalledWith({
-      $or: [{ "confirmedUsers.id": "1234TestAuthUser" }, { users: "testAuthUser@test.com" }]
+      $or: [{ "confirmedUsers.id": "addaddaddaddaddaddaddadd" }, { users: "testAuthUser@test.com" }]
     });
   });
 
@@ -126,7 +130,7 @@ describe("GET /v3/myteams", () => {
         ],
         confirmedUsers: [
           {
-            id: "1234TestAuthUser",
+            id: "addaddaddaddaddaddaddadd",
             email: "testAuthUser@test.com"
           }
         ]
@@ -171,7 +175,7 @@ describe("GET /v3/myteams", () => {
         ],
         confirmedUsers: [
           {
-            id: "1234TestAuthUser",
+            id: "addaddaddaddaddaddaddadd",
             email: "testAuthUser@test.com"
           }
         ]

--- a/app/src/serializers/teamWithUserRole.serializer.ts
+++ b/app/src/serializers/teamWithUserRole.serializer.ts
@@ -6,7 +6,17 @@ const Serializer = new JSONAPISerializer();
 Serializer.register("team", {
   jsonapiObject: false,
   id: "id",
-  whitelist: ["name", "managers", "userRole", "users", "areas", "layers", "confirmedUsers", "createdAt"],
+  whitelist: [
+    "name",
+    "administrator",
+    "managers",
+    "userRole",
+    "users",
+    "areas",
+    "layers",
+    "confirmedUsers",
+    "createdAt"
+  ],
   convertCase: "camelCase"
 });
 

--- a/app/src/test/jest/setupTests.ts
+++ b/app/src/test/jest/setupTests.ts
@@ -2,7 +2,7 @@
 // See: https://jestjs.io/docs/configuration#setupfilesafterenv-array
 
 const user = {
-  id: "1234TestAuthUser",
+  id: "addaddaddaddaddaddaddadd",
   email: "testAuthUser@test.com"
 };
 


### PR DESCRIPTION
Administrator key added to teams schema.

A users id is now stored on the team schema so that the admin of the team can be identified.

Currently when a team is created the admin key is not populated, PR to come!