### PR TITLE
Get all users on a team

### DIFF
--- a/app/src/middlewares/isUser.ts
+++ b/app/src/middlewares/isUser.ts
@@ -17,12 +17,12 @@ export const isUser: Middleware = async (ctx, next) => {
   const { body, query } = <TRequest>ctx.request;
   const { id: userId } = body.loggedUser || JSON.parse(query.loggedUser); // ToDo: loggedUser Type
 
-  try {
-    await TeamUserRelationModel.findOne({
-      teamId,
-      userId
-    });
-  } catch (e) {
+  const teamUserRelation = await TeamUserRelationModel.findOne({
+    teamId,
+    userId
+  });
+
+  if (!teamUserRelation || teamUserRelation.role === EUserRole.Left) {
     ctx.status = 401;
     throw new Error("Authenticated User must be part of the team");
   }

--- a/app/src/models/team.model.ts
+++ b/app/src/models/team.model.ts
@@ -1,10 +1,12 @@
 import mongoose from "mongoose";
 import Joi from "joi";
+import { EUserRole } from "./teamUserRelation.model";
 
 const { Schema } = mongoose;
 
 export interface ITeam {
   name: string;
+  userRole: EUserRole;
   createdAt: string;
 }
 

--- a/app/src/serializers/gfwTeam.serializer.ts
+++ b/app/src/serializers/gfwTeam.serializer.ts
@@ -6,7 +6,7 @@ const Serializer = new JSONAPISerializer();
 Serializer.register("team", {
   jsonapiObject: false,
   id: "id",
-  whitelist: ["name", "createdAt"],
+  whitelist: ["name", "userRole", "createdAt"],
   convertCase: "camelCase"
 });
 

--- a/app/src/services/teamUserRelation.service.ts
+++ b/app/src/services/teamUserRelation.service.ts
@@ -1,4 +1,4 @@
-import { TeamModel } from "models/team.model";
+import { ITeamModel, TeamModel } from "models/team.model";
 import { TeamUserRelationModel } from "models/teamUserRelation.model";
 
 class TeamUserRelationService {
@@ -8,9 +8,18 @@ class TeamUserRelationService {
       ...conditions
     });
 
-    const teamIdsToFind = teamUserRelations.map(teamUserRelation => teamUserRelation.teamId);
+    const teams: ITeamModel[] = [];
+    for (let i = 0; i < teamUserRelations.length; i++) {
+      const teamUser = teamUserRelations[i];
 
-    return TeamModel.find({ _id: { $in: teamIdsToFind } });
+      const team = await TeamModel.findById(teamUser.teamId);
+
+      team.userRole = teamUser.role;
+
+      teams.push(team);
+    }
+
+    return teams;
   }
 }
 


### PR DESCRIPTION
created GET /v3/teams/:teamId/user

Returns all users for the given them if the auth user is part of the team. If the auth user is a manager or admin the endpoint returns the status of the users and if the auth user is a monitor the endpoint doesn't return the status.

User role attribute added add to get teams. This means GET /v3/teams and /v3/teams/user/:userId returns the teams and the role the user has within the team.

No tests or typescript types, PR to come!