### PR TITLE
/v3/teams/myinvites now finds the invited teams by userEmail

### DIFF
--- a/app/src/routes/v3/teams/index.router.ts
+++ b/app/src/routes/v3/teams/index.router.ts
@@ -3,9 +3,7 @@ import Router from "koa-router";
 import { authMiddleware, validatorMiddleware, isAdminOrManager, validateObjectId, isAdmin, isUser } from "middlewares";
 import createTeamInput from "./dto/create-team.input";
 import updateTeamInput from "./dto/update-team.input";
-import { EUserStatus } from "models/teamUserRelation.model";
 import TeamService from "services/team.service";
-import TeamUserRelationService from "services/teamUserRelation.service";
 import gfwTeamSerializer from "serializers/gfwTeam.serializer";
 
 type TRequest = {
@@ -23,11 +21,9 @@ const router = new Router();
 // Find teams that auth user is invited to
 router.get("/myinvites", authMiddleware, async ctx => {
   const query = <TQuery>ctx.request.query;
-  const { id: userId } = JSON.parse(query.loggedUser); // ToDo: loggedUser Type
+  const { email: loggedEmail } = JSON.parse(query.loggedUser); // ToDo: loggedUser Type
 
-  const teams = await TeamUserRelationService.getTeamsByUserId(userId, {
-    status: EUserStatus.Invited
-  });
+  const teams = await TeamService.findAllInvites(loggedEmail);
 
   ctx.body = gfwTeamSerializer(teams);
 });
@@ -48,7 +44,7 @@ router.get("/:teamId", authMiddleware, validateObjectId("teamId"), isUser, async
 router.get("/user/:userId", authMiddleware, validateObjectId("userId"), async ctx => {
   const { userId } = ctx.params;
 
-  const teams = await TeamUserRelationService.getTeamsByUserId(userId);
+  const teams = await TeamService.findAllByUserId(userId);
 
   ctx.body = gfwTeamSerializer(teams);
 });

--- a/app/src/routes/v3/teams/teams.test.ts
+++ b/app/src/routes/v3/teams/teams.test.ts
@@ -36,22 +36,20 @@ describe("/v3/teams", () => {
       teamUserDocuments = [
         {
           teamId: new ObjectId(teams[0]._id),
-          userId: new ObjectId("addaddaddaddaddaddaddadd"),
-          email: "admin@user.com",
+          email: "testAuthUser@test.com",
           role: EUserRole.Manager,
           status: EUserStatus.Invited
         },
         {
           teamId: new ObjectId(teams[1]._id),
           userId: new ObjectId("addaddaddaddaddaddaddadd"),
-          email: "admin@user.com",
+          email: "testAuthUser@test.com",
           role: EUserRole.Monitor,
           status: EUserStatus.Confirmed
         },
         {
           teamId: new ObjectId(teams[2]._id),
-          userId: new ObjectId("addaddaddaddaddaddaddadd"),
-          email: "admin@user.com",
+          email: "testAuthUser@test.com",
           role: EUserRole.Monitor,
           status: EUserStatus.Invited
         }
@@ -91,15 +89,15 @@ describe("/v3/teams", () => {
       teamUserDocuments = [
         {
           ...teamUserDocuments[0],
-          userId: new ObjectId()
+          email: "notMe@test.com"
         },
         {
           ...teamUserDocuments[1],
-          userId: new ObjectId()
+          email: "notMe@test.com"
         },
         {
           ...teamUserDocuments[2],
-          userId: new ObjectId()
+          email: "notMe@test.com"
         }
       ];
 

--- a/app/src/services/team.service.ts
+++ b/app/src/services/team.service.ts
@@ -1,5 +1,6 @@
 import TeamModel, { ITeamModel, ITeam } from "models/team.model";
-import TeamUserRelationModel, { EUserRole, EUserStatus } from "models/teamUserRelation.model";
+import TeamUserRelationModel, { EUserRole, EUserStatus, ITeamUserRelationModel } from "models/teamUserRelation.model";
+import TeamUserRelationService from "services/teamUserRelation.service";
 
 class TeamService {
   static async create(name: ITeam["name"], loggedUser: any): Promise<ITeamModel> {
@@ -41,6 +42,33 @@ class TeamService {
 
   static findById(id: string) {
     return TeamModel.findById(id);
+  }
+
+  static async findAllInvites(userEmail: string): Promise<ITeamModel[]> {
+    const teamUserRelations = await TeamUserRelationService.findAllInvitesByUserEmail(userEmail);
+
+    return await TeamService.findAllByTeamUserRelations(teamUserRelations);
+  }
+
+  static async findAllByUserId(userId: string): Promise<ITeamModel[]> {
+    const teamUserRelations = await TeamUserRelationService.findAllByUserId(userId);
+
+    return await TeamService.findAllByTeamUserRelations(teamUserRelations);
+  }
+
+  static async findAllByTeamUserRelations(teamUserRelations: ITeamUserRelationModel[]): Promise<ITeamModel[]> {
+    const teams: ITeamModel[] = [];
+    for (let i = 0; i < teamUserRelations.length; i++) {
+      const teamUser = teamUserRelations[i];
+
+      const team = await TeamService.findById(teamUser.teamId);
+
+      team.userRole = teamUser.role;
+
+      teams.push(team);
+    }
+
+    return teams;
   }
 }
 

--- a/app/src/services/teamUserRelation.service.ts
+++ b/app/src/services/teamUserRelation.service.ts
@@ -1,26 +1,17 @@
-import { ITeamModel } from "models/team.model";
-import { TeamUserRelationModel } from "models/teamUserRelation.model";
-import TeamService from "services/team.service";
+import { EUserStatus, TeamUserRelationModel } from "models/teamUserRelation.model";
 
 class TeamUserRelationService {
-  static async getTeamsByUserId(userId: string, conditions = {}) {
-    const teamUserRelations = await TeamUserRelationModel.find({
-      userId,
-      ...conditions
+  static findAllByUserId(userId: string) {
+    return TeamUserRelationModel.find({
+      userId
     });
+  }
 
-    const teams: ITeamModel[] = [];
-    for (let i = 0; i < teamUserRelations.length; i++) {
-      const teamUser = teamUserRelations[i];
-
-      const team = await TeamService.findById(teamUser.teamId);
-
-      team.userRole = teamUser.role;
-
-      teams.push(team);
-    }
-
-    return teams;
+  static findAllInvitesByUserEmail(userEmail: string) {
+    return TeamUserRelationModel.find({
+      email: userEmail,
+      status: EUserStatus.Invited
+    });
   }
 }
 


### PR DESCRIPTION
Due to this ticket failing testing [https://3sidedcube.atlassian.net/browse/GFW-1093](https://3sidedcube.atlassian.net/browse/GFW-1093)

`GET /v3/teams/myinvites` now finds the invited teams by the user's email address instead of their id.

This is need because `POST /v3/teams/:teamId/users` creates new teamUserRelations with only their email address known, this is so users without an account (no userId) can be invited initially.

Also moved getTeamsByUserId from teamUser service to the teams service, as the returned result was an array of teams not array of teamUsers.