### PR TITLE
team user relation services

### DIFF
--- a/app/src/middlewares/isAdmin.ts
+++ b/app/src/middlewares/isAdmin.ts
@@ -1,6 +1,7 @@
 import { Middleware, Request } from "koa";
-import { TeamUserRelationModel, EUserRole } from "models/teamUserRelation.model";
+import { EUserRole } from "models/teamUserRelation.model";
 import TeamModel from "../models/team.model";
+import TeamUserRelationService from "../services/teamUserRelation.service";
 
 type TRequest = {
   body: {
@@ -25,10 +26,7 @@ export const isAdmin: Middleware = async (ctx, next) => {
     throw new Error(`Team not found with id: ${teamId}`);
   }
 
-  const teamUserRelation = await TeamUserRelationModel.findOne({
-    teamId,
-    userId
-  });
+  const teamUserRelation = await TeamUserRelationService.findTeamUser(teamId, userId);
 
   if (teamUserRelation && teamUserRelation.role === EUserRole.Administrator) {
     await next();

--- a/app/src/middlewares/isAdminOrManager.ts
+++ b/app/src/middlewares/isAdminOrManager.ts
@@ -1,6 +1,7 @@
 import { Middleware, Request } from "koa";
-import { TeamUserRelationModel, EUserRole } from "models/teamUserRelation.model";
+import { EUserRole } from "models/teamUserRelation.model";
 import { TeamModel } from "models/team.model";
+import TeamUserRelationService from "../services/teamUserRelation.service";
 
 type TRequest = {
   body: {
@@ -25,10 +26,7 @@ export const isAdminOrManager: Middleware = async (ctx, next) => {
     throw new Error(`Team not found with id: ${teamId}`);
   }
 
-  const teamUserRelation = await TeamUserRelationModel.findOne({
-    teamId,
-    userId
-  });
+  const teamUserRelation = await TeamUserRelationService.findTeamUser(teamId, userId);
 
   if (
     teamUserRelation &&

--- a/app/src/middlewares/isUser.ts
+++ b/app/src/middlewares/isUser.ts
@@ -1,6 +1,7 @@
 import { Middleware, Request } from "koa";
-import { TeamUserRelationModel, EUserRole } from "models/teamUserRelation.model";
+import { EUserRole } from "models/teamUserRelation.model";
 import { TeamModel } from "models/team.model";
+import TeamUserRelationService from "../services/teamUserRelation.service";
 
 type TRequest = {
   body: {
@@ -25,10 +26,7 @@ export const isUser: Middleware = async (ctx, next) => {
     throw new Error(`Team not found with id: ${teamId}`);
   }
 
-  const teamUserRelation = await TeamUserRelationModel.findOne({
-    teamId,
-    userId
-  });
+  const teamUserRelation = await TeamUserRelationService.findTeamUser(teamId, userId);
 
   if (!teamUserRelation || teamUserRelation.role === EUserRole.Left) {
     ctx.status = 401;

--- a/app/src/routes/v3/teams/teamUsers.router.ts
+++ b/app/src/routes/v3/teams/teamUsers.router.ts
@@ -11,6 +11,7 @@ import {
 } from "models/teamUserRelation.model";
 import { Request } from "koa";
 import serializeTeamUser from "serializers/teamUserRelation.serializer";
+import TeamUserRelationService from "services/teamUserRelation.service";
 
 const router = new Router({
   prefix: "/:teamId/users"
@@ -32,10 +33,7 @@ router.get("/", authMiddleware, validateObjectId("teamId"), isUser, async ctx =>
   const { query } = <TRequest>ctx.request;
   const { id: userId } = JSON.parse(query.loggedUser); // ToDo: loggedUser Type
 
-  const teamUserRelation = await TeamUserRelationModel.findOne({
-    teamId,
-    userId
-  });
+  const teamUserRelation = await TeamUserRelationService.findTeamUser(teamId, userId);
 
   let users: ITeamUserRelationModel[] = [];
   if (teamUserRelation.role === EUserRole.Administrator || teamUserRelation.role === EUserRole.Manager) {
@@ -195,10 +193,7 @@ router.patch("/:userId/leave", authMiddleware, validateObjectId(["teamId", "user
     throw new Error("Log in with the correct user");
   }
 
-  const teamUserRelation = await TeamUserRelationModel.findOne({
-    teamId,
-    userId
-  });
+  const teamUserRelation = await TeamUserRelationService.findTeamUser(teamId, userId);
 
   if (teamUserRelation && teamUserRelation.role === EUserRole.Administrator) {
     ctx.status = 400;

--- a/app/src/routes/v3/teams/teamUsers.router.ts
+++ b/app/src/routes/v3/teams/teamUsers.router.ts
@@ -37,9 +37,9 @@ router.get("/", authMiddleware, validateObjectId("teamId"), isUser, async ctx =>
 
   let users: ITeamUserRelationModel[] = [];
   if (teamUserRelation.role === EUserRole.Administrator || teamUserRelation.role === EUserRole.Manager) {
-    users = await TeamUserRelationModel.find({ teamId });
+    users = await TeamUserRelationService.findAllUsersOnTeam(teamId);
   } else {
-    users = await TeamUserRelationModel.find({ teamId }).select("-status");
+    users = await TeamUserRelationService.findAllUsersOnTeam(teamId).select("-status");
   }
 
   ctx.body = serializeTeamUser(users);

--- a/app/src/routes/v3/teams/teamUsers.router.ts
+++ b/app/src/routes/v3/teams/teamUsers.router.ts
@@ -115,7 +115,7 @@ router.patch(
       throw new Error("Can't set user as administrator");
     }
 
-    const teamUser = await TeamUserRelationModel.findById(teamUserId);
+    const teamUser = await TeamUserRelationService.findById(teamUserId);
 
     if (teamUser.role === EUserRole.Administrator) {
       ctx.status = 400;

--- a/app/src/routes/v3/teams/teamUsers.router.ts
+++ b/app/src/routes/v3/teams/teamUsers.router.ts
@@ -1,13 +1,13 @@
 import Router from "koa-router";
-import { authMiddleware, isAdminOrManager, isUser, validatorMiddleware, validateObjectId } from "middlewares";
+import { authMiddleware, isAdminOrManager, isUser, validateObjectId, validatorMiddleware } from "middlewares";
 import createTeamUsersInput from "./dto/create-team-users.input";
 import updateTeamUsersInput from "./dto/update-team-user.input";
 import {
-  TeamUserRelationModel,
+  EUserRole,
+  EUserStatus,
   ITeamUserRelation,
   ITeamUserRelationModel,
-  EUserRole,
-  EUserStatus
+  TeamUserRelationModel
 } from "models/teamUserRelation.model";
 import { Request } from "koa";
 import serializeTeamUser from "serializers/teamUserRelation.serializer";
@@ -143,14 +143,10 @@ router.patch("/:userId/accept", authMiddleware, validateObjectId(["teamId", "use
     throw new Error("Login with the correct user");
   }
 
-  const updatedUser = await TeamUserRelationModel.findOneAndUpdate(
-    { teamId, email: loggedEmail },
-    {
-      userId: loggedUserId,
-      status: EUserStatus.Confirmed
-    },
-    { new: true }
-  );
+  const updatedUser = await TeamUserRelationService.update(teamId, loggedEmail, {
+    userId: loggedUserId,
+    status: EUserStatus.Confirmed
+  });
 
   ctx.body = serializeTeamUser(updatedUser);
 });
@@ -161,20 +157,16 @@ router.patch("/:userId/accept", authMiddleware, validateObjectId(["teamId", "use
 router.patch("/:userId/decline", authMiddleware, validateObjectId(["teamId", "userId"]), async ctx => {
   const { teamId, userId } = ctx.params;
   const { body } = <TRequest>ctx.request;
-  const { id: loggedUserId, email: loggedEmailId } = body.loggedUser; // ToDo: loggedUser Type
+  const { id: loggedUserId, email: loggedEmail } = body.loggedUser; // ToDo: loggedUser Type
 
   if (userId !== loggedUserId) {
     ctx.status = 401;
     throw new Error("Log in with the correct user");
   }
 
-  const updatedUser = await TeamUserRelationModel.findOneAndUpdate(
-    { teamId, email: loggedEmailId },
-    {
-      status: EUserStatus.Declined
-    },
-    { new: true }
-  );
+  const updatedUser = await TeamUserRelationService.update(teamId, loggedEmail, {
+    status: EUserStatus.Declined
+  });
 
   ctx.body = serializeTeamUser(updatedUser);
 });
@@ -186,7 +178,7 @@ router.patch("/:userId/decline", authMiddleware, validateObjectId(["teamId", "us
 router.patch("/:userId/leave", authMiddleware, validateObjectId(["teamId", "userId"]), async ctx => {
   const { teamId, userId } = ctx.params;
   const { body } = <TRequest>ctx.request;
-  const { id: loggedUserId, email: loggedEmailId } = body.loggedUser; // ToDo: loggedUser Type
+  const { id: loggedUserId, email: loggedEmail } = body.loggedUser; // ToDo: loggedUser Type
 
   if (userId !== loggedUserId) {
     ctx.status = 401;
@@ -200,13 +192,9 @@ router.patch("/:userId/leave", authMiddleware, validateObjectId(["teamId", "user
     throw new Error("Administrator can't leave team");
   }
 
-  const updatedUser = await TeamUserRelationModel.findOneAndUpdate(
-    { teamId, email: loggedEmailId },
-    {
-      role: EUserRole.Left
-    },
-    { new: true }
-  );
+  const updatedUser = await TeamUserRelationService.update(teamId, loggedEmail, {
+    role: EUserRole.Left
+  });
 
   ctx.body = serializeTeamUser(updatedUser);
 });

--- a/app/src/routes/v3/teams/teamUsers.router.ts
+++ b/app/src/routes/v3/teams/teamUsers.router.ts
@@ -79,7 +79,7 @@ router.post(
       throw new Error("Can't have duplicate users on a team");
     }
 
-    const userDocumentsToAdd = users.map(user => {
+    const userDocumentsToAdd = users.map<ITeamUserRelation>(user => {
       return {
         teamId,
         email: user.email,
@@ -88,7 +88,7 @@ router.post(
       };
     });
 
-    const userDocuments = await TeamUserRelationModel.insertMany(userDocumentsToAdd);
+    const userDocuments = await TeamUserRelationService.createMany(userDocumentsToAdd);
 
     // ToDo: Send Invitations "userEmails"
 

--- a/app/src/services/team.service.ts
+++ b/app/src/services/team.service.ts
@@ -1,5 +1,5 @@
 import TeamModel, { ITeamModel, ITeam } from "models/team.model";
-import TeamUserRelationModel, { EUserRole, EUserStatus, ITeamUserRelationModel } from "models/teamUserRelation.model";
+import { EUserRole, EUserStatus, ITeamUserRelationModel } from "models/teamUserRelation.model";
 import TeamUserRelationService from "services/teamUserRelation.service";
 
 class TeamService {
@@ -10,13 +10,14 @@ class TeamService {
 
     // Create the Team User relation model
     // The logged-in user will become the "Administrator" of the team
-    await new TeamUserRelationModel({
-      teamId: team.id,
+    await TeamUserRelationService.create({
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      teamId: team.id!,
       userId: userId,
       email: userEmail,
       role: EUserRole.Administrator,
       status: EUserStatus.Confirmed
-    }).save();
+    });
 
     return team;
   }
@@ -35,9 +36,7 @@ class TeamService {
     await TeamModel.findByIdAndRemove(id);
 
     // Remove all team user relations
-    await TeamUserRelationModel.remove({
-      teamId: id
-    });
+    await TeamUserRelationService.removeAllUsersOnTeam(id);
   }
 
   static findById(id: string) {

--- a/app/src/services/teamUserRelation.service.ts
+++ b/app/src/services/teamUserRelation.service.ts
@@ -1,6 +1,10 @@
-import { EUserStatus, TeamUserRelationModel } from "models/teamUserRelation.model";
+import { EUserStatus, ITeamUserRelation, TeamUserRelationModel } from "models/teamUserRelation.model";
 
 class TeamUserRelationService {
+  static createMany(teamUsersToAdd: ITeamUserRelation[]) {
+    return TeamUserRelationModel.insertMany(teamUsersToAdd);
+  }
+
   static findTeamUser(teamId: string, userId: string) {
     return TeamUserRelationModel.findOne({
       teamId,

--- a/app/src/services/teamUserRelation.service.ts
+++ b/app/src/services/teamUserRelation.service.ts
@@ -8,6 +8,10 @@ class TeamUserRelationService {
     });
   }
 
+  static findAllUsersOnTeam(teamId: string) {
+    return TeamUserRelationModel.find({ teamId });
+  }
+
   static findAllByUserId(userId: string) {
     return TeamUserRelationModel.find({
       userId

--- a/app/src/services/teamUserRelation.service.ts
+++ b/app/src/services/teamUserRelation.service.ts
@@ -1,12 +1,22 @@
 import { EUserStatus, ITeamUserRelation, TeamUserRelationModel } from "models/teamUserRelation.model";
 
 class TeamUserRelationService {
+  static create(team: ITeamUserRelation) {
+    return new TeamUserRelationModel(team).save();
+  }
+
   static createMany(teamUsersToAdd: ITeamUserRelation[]) {
     return TeamUserRelationModel.insertMany(teamUsersToAdd);
   }
 
   static update(teamId: string, userEmail: string, update: Partial<ITeamUserRelation>) {
     return TeamUserRelationModel.findOneAndUpdate({ teamId, email: userEmail }, update, { new: true });
+  }
+
+  static removeAllUsersOnTeam(teamId: string) {
+    return TeamUserRelationModel.remove({
+      teamId
+    });
   }
 
   static findTeamUser(teamId: string, userId: string) {

--- a/app/src/services/teamUserRelation.service.ts
+++ b/app/src/services/teamUserRelation.service.ts
@@ -5,6 +5,10 @@ class TeamUserRelationService {
     return TeamUserRelationModel.insertMany(teamUsersToAdd);
   }
 
+  static update(teamId: string, userEmail: string, update: Partial<ITeamUserRelation>) {
+    return TeamUserRelationModel.findOneAndUpdate({ teamId, email: userEmail }, update, { new: true });
+  }
+
   static findTeamUser(teamId: string, userId: string) {
     return TeamUserRelationModel.findOne({
       teamId,

--- a/app/src/services/teamUserRelation.service.ts
+++ b/app/src/services/teamUserRelation.service.ts
@@ -1,6 +1,13 @@
 import { EUserStatus, TeamUserRelationModel } from "models/teamUserRelation.model";
 
 class TeamUserRelationService {
+  static findTeamUser(teamId: string, userId: string) {
+    return TeamUserRelationModel.findOne({
+      teamId,
+      userId
+    });
+  }
+
   static findAllByUserId(userId: string) {
     return TeamUserRelationModel.find({
       userId

--- a/app/src/services/teamUserRelation.service.ts
+++ b/app/src/services/teamUserRelation.service.ts
@@ -12,6 +12,10 @@ class TeamUserRelationService {
     });
   }
 
+  static findById(id: string) {
+    return TeamUserRelationModel.findById(id);
+  }
+
   static findAllUsersOnTeam(teamId: string) {
     return TeamUserRelationModel.find({ teamId });
   }


### PR DESCRIPTION
All database mutations for teamUserRelations now moved to `app/src/services/teamUserRelation.service.ts`. This is so the type checking is better! 

routers updated to use the service instead.

All tests still pass.