### PR TITLE
Urgent: Staging URLs updated (small)

### DIFF
--- a/docker-compose-develop.yml
+++ b/docker-compose-develop.yml
@@ -19,8 +19,8 @@ services:
       REDIS_URL: redis://redis:6379
       REDIS_QUEUE_NAME: mail
       APP_URL: http://127.0.0.1:3035
-      USERS_API_URL: https://api.resourcewatch.org
-      CONTROL_TOWER_URL: https://api.resourcewatch.org
+      USERS_API_URL: https://staging-api.resourcewatch.org/v1
+      CONTROL_TOWER_URL: https://staging-api.resourcewatch.org
     volumes:
       - ./app:/opt/fw-teams/app
     depends_on:

--- a/terraform/vars/terraform-dev.tfvars
+++ b/terraform/vars/terraform-dev.tfvars
@@ -10,8 +10,8 @@ NODE_PATH         = "app/src"
 JWT_SECRET        = "@@JWT_SECRET@@"
 redis_queue_name  = "mail"
 APP_URL           = "http://127.0.0.1:80"
-USERS_API_URL     = "https://api.resourcewatch.org/v1"
-CONTROL_TOWER_URL = "https://api.resourcewatch.org"
+USERS_API_URL     = "https://staging-api.resourcewatch.org/v1"
+CONTROL_TOWER_URL = "https://staging-api.resourcewatch.org"
 
 healthcheck_path = "/v1/fw_teams/healthcheck"
 healthcheck_sns_emails = ["server@3sidedcube.com"]

--- a/terraform/vars/terraform-staging.tfvars
+++ b/terraform/vars/terraform-staging.tfvars
@@ -10,7 +10,7 @@ NODE_PATH         = "app/src"
 JWT_SECRET        = "overridden_in_github_secrets"
 redis_queue_name  = "mail"
 APP_URL           = "https://gfw-web-staging.cube-cdn.com"
-USERS_API_URL     = "https://gfw-staging.globalforestwatch.org/v1"
+USERS_API_URL     = "https://staging-api.resourcewatch.org/v1"
 CONTROL_TOWER_URL = "https://staging-api.resourcewatch.org"
 
 healthcheck_path = "/v1/fw_teams/healthcheck"


### PR DESCRIPTION
The Staging, Dev and Local environments were still using the production APIs or the old staging API. These have been update.