### PR TITLE
Mid: logged user type (medium)

### DIFF
--- a/app/src/routes/v3/teams/index.router.ts
+++ b/app/src/routes/v3/teams/index.router.ts
@@ -1,5 +1,5 @@
 import Router from "koa-router";
-import { TKoaRequest } from "types/koa-request";
+import { TKoaRequest, TLoggedUser } from "types/koa-request";
 import { authMiddleware, validatorMiddleware, isAdminOrManager, validateObjectId, isAdmin, isUser } from "middlewares";
 import createTeamInput, { DTOCreateTeam } from "./dto/create-team.input";
 import updateTeamInput, { DTOUpdateTeam } from "./dto/update-team.input";
@@ -12,7 +12,7 @@ const router = new Router();
 // Find teams that auth user is invited to
 router.get("/myinvites", authMiddleware, async ctx => {
   const { query } = <TKoaRequest>ctx.request;
-  const { email: loggedEmail } = JSON.parse(query.loggedUser);
+  const { email: loggedEmail } = <TLoggedUser>JSON.parse(query.loggedUser);
 
   const teams = await TeamService.findAllInvites(loggedEmail);
 

--- a/app/src/routes/v3/teams/index.router.ts
+++ b/app/src/routes/v3/teams/index.router.ts
@@ -1,27 +1,18 @@
-import { Request } from "koa";
 import Router from "koa-router";
+import { TKoaRequest } from "types/koa-request";
 import { authMiddleware, validatorMiddleware, isAdminOrManager, validateObjectId, isAdmin, isUser } from "middlewares";
-import createTeamInput from "./dto/create-team.input";
-import updateTeamInput from "./dto/update-team.input";
+import createTeamInput, { DTOCreateTeam } from "./dto/create-team.input";
+import updateTeamInput, { DTOUpdateTeam } from "./dto/update-team.input";
 import TeamService from "services/team.service";
 import gfwTeamSerializer from "serializers/gfwTeam.serializer";
-
-type TRequest = {
-  body: any; // ToDo: request body
-} & Request;
-
-type TQuery = {
-  loggedUser: string;
-  userRole?: string;
-};
 
 const router = new Router();
 
 // GET /v3/teams/myinvites
 // Find teams that auth user is invited to
 router.get("/myinvites", authMiddleware, async ctx => {
-  const query = <TQuery>ctx.request.query;
-  const { email: loggedEmail } = JSON.parse(query.loggedUser); // ToDo: loggedUser Type
+  const { query } = <TKoaRequest>ctx.request;
+  const { email: loggedEmail } = JSON.parse(query.loggedUser);
 
   const teams = await TeamService.findAllInvites(loggedEmail);
 
@@ -52,7 +43,7 @@ router.get("/user/:userId", authMiddleware, validateObjectId("userId"), async ct
 // POST /v3/teams
 // Add user as admin to teamUserRelation model
 router.post("/", authMiddleware, validatorMiddleware(createTeamInput), async ctx => {
-  const { body } = <TRequest>ctx.request;
+  const { body } = <TKoaRequest<DTOCreateTeam>>ctx.request;
 
   const team = await TeamService.create(body.name, body.loggedUser);
 
@@ -69,7 +60,7 @@ router.patch(
   isAdminOrManager,
   async ctx => {
     const { teamId } = ctx.params;
-    const { body } = <TRequest>ctx.request;
+    const { body } = <TKoaRequest<DTOUpdateTeam>>ctx.request;
 
     const team = await TeamService.update(teamId, body.name);
 

--- a/app/src/routes/v3/teams/teamUsers.router.ts
+++ b/app/src/routes/v3/teams/teamUsers.router.ts
@@ -1,5 +1,5 @@
 import Router from "koa-router";
-import { TKoaRequest } from "types/koa-request";
+import { TKoaRequest, TLoggedUser } from "types/koa-request";
 import { authMiddleware, isAdminOrManager, isUser, validateObjectId, validatorMiddleware } from "middlewares";
 import createTeamUsersInput, { DTOCreateTeamUsers } from "./dto/create-team-users.input";
 import updateTeamUsersInput, { DTOUpdateTeamUsers } from "./dto/update-team-user.input";
@@ -22,7 +22,7 @@ const router = new Router({
 router.get("/", authMiddleware, validateObjectId("teamId"), isUser, async ctx => {
   const { teamId } = ctx.params;
   const { query } = <TKoaRequest>ctx.request;
-  const { id: userId } = JSON.parse(query.loggedUser);
+  const { id: userId } = <TLoggedUser>JSON.parse(query.loggedUser);
 
   const teamUserRelation = await TeamUserRelationService.findTeamUser(teamId, userId);
 

--- a/app/src/routes/v3/teams/teamUsers.router.ts
+++ b/app/src/routes/v3/teams/teamUsers.router.ts
@@ -1,7 +1,8 @@
 import Router from "koa-router";
+import { TKoaRequest } from "types/koa-request";
 import { authMiddleware, isAdminOrManager, isUser, validateObjectId, validatorMiddleware } from "middlewares";
-import createTeamUsersInput from "./dto/create-team-users.input";
-import updateTeamUsersInput from "./dto/update-team-user.input";
+import createTeamUsersInput, { DTOCreateTeamUsers } from "./dto/create-team-users.input";
+import updateTeamUsersInput, { DTOUpdateTeamUsers } from "./dto/update-team-user.input";
 import {
   EUserRole,
   EUserStatus,
@@ -9,7 +10,6 @@ import {
   ITeamUserRelationModel,
   TeamUserRelationModel
 } from "models/teamUserRelation.model";
-import { Request } from "koa";
 import serializeTeamUser from "serializers/teamUserRelation.serializer";
 import TeamUserRelationService from "services/teamUserRelation.service";
 
@@ -17,21 +17,12 @@ const router = new Router({
   prefix: "/:teamId/users"
 });
 
-type TRequest = {
-  query: any;
-  body: {
-    loggedUser: any;
-    users: ITeamUserRelation[];
-    role: ITeamUserRelation["role"];
-  }; // ToDo: request body
-} & Request;
-
 // GET /v3/teams/:teamId/users
 // Return all users on a team
 router.get("/", authMiddleware, validateObjectId("teamId"), isUser, async ctx => {
   const { teamId } = ctx.params;
-  const { query } = <TRequest>ctx.request;
-  const { id: userId } = JSON.parse(query.loggedUser); // ToDo: loggedUser Type
+  const { query } = <TKoaRequest>ctx.request;
+  const { id: userId } = JSON.parse(query.loggedUser);
 
   const teamUserRelation = await TeamUserRelationService.findTeamUser(teamId, userId);
 
@@ -58,7 +49,7 @@ router.post(
     const { teamId } = ctx.params;
     const {
       body: { users }
-    } = <TRequest>ctx.request;
+    } = <TKoaRequest<DTOCreateTeamUsers>>ctx.request;
 
     const userEmails: string[] = [];
     for (let i = 0; i < users.length; i++) {
@@ -108,12 +99,7 @@ router.patch(
   isAdminOrManager,
   async ctx => {
     const { teamUserId } = ctx.params;
-    const { body } = <TRequest>ctx.request;
-
-    if (body.role === EUserRole.Administrator) {
-      ctx.status = 401;
-      throw new Error("Can't set user as administrator");
-    }
+    const { body } = <TKoaRequest<DTOUpdateTeamUsers>>ctx.request;
 
     const teamUser = await TeamUserRelationService.findById(teamUserId);
 
@@ -135,8 +121,8 @@ router.patch(
 // Only if JWT's userid match the one in the URL
 router.patch("/:userId/accept", authMiddleware, validateObjectId(["teamId", "userId"]), async ctx => {
   const { teamId, userId } = ctx.params;
-  const { body } = <TRequest>ctx.request;
-  const { id: loggedUserId, email: loggedEmail } = body.loggedUser; // ToDo: loggedUser Type
+  const { body } = <TKoaRequest>ctx.request;
+  const { id: loggedUserId, email: loggedEmail } = body.loggedUser;
 
   if (userId !== loggedUserId) {
     ctx.status = 401;
@@ -156,8 +142,8 @@ router.patch("/:userId/accept", authMiddleware, validateObjectId(["teamId", "use
 // Only if JWT's userid match the one in the URL
 router.patch("/:userId/decline", authMiddleware, validateObjectId(["teamId", "userId"]), async ctx => {
   const { teamId, userId } = ctx.params;
-  const { body } = <TRequest>ctx.request;
-  const { id: loggedUserId, email: loggedEmail } = body.loggedUser; // ToDo: loggedUser Type
+  const { body } = <TKoaRequest>ctx.request;
+  const { id: loggedUserId, email: loggedEmail } = body.loggedUser;
 
   if (userId !== loggedUserId) {
     ctx.status = 401;
@@ -177,8 +163,8 @@ router.patch("/:userId/decline", authMiddleware, validateObjectId(["teamId", "us
 // Unless auth user is admin
 router.patch("/:userId/leave", authMiddleware, validateObjectId(["teamId", "userId"]), async ctx => {
   const { teamId, userId } = ctx.params;
-  const { body } = <TRequest>ctx.request;
-  const { id: loggedUserId, email: loggedEmail } = body.loggedUser; // ToDo: loggedUser Type
+  const { body } = <TKoaRequest>ctx.request;
+  const { id: loggedUserId, email: loggedEmail } = body.loggedUser;
 
   if (userId !== loggedUserId) {
     ctx.status = 401;

--- a/app/src/types/koa-request.ts
+++ b/app/src/types/koa-request.ts
@@ -1,11 +1,16 @@
 import { Request } from "koa";
 
+export type TLoggedUser = {
+  id: string;
+  email: string;
+};
+
 export type TKoaRequest<Body = object, Query = object> = {
   body: {
-    loggedUser: any; // ToDo: loggedUser Type
+    loggedUser: TLoggedUser;
   } & Body;
   query: {
-    loggedUser: string; // ToDo: loggedUser Type
+    loggedUser: string;
   } & Query &
     Request["query"];
 } & Request;

--- a/app/src/types/koa-request.ts
+++ b/app/src/types/koa-request.ts
@@ -1,10 +1,11 @@
 import { Request } from "koa";
 
-export type TKoaRequest<Body = object, Query extends Request["query"]> = {
+export type TKoaRequest<Body = object, Query = object> = {
   body: {
-    loggedUser: any;
+    loggedUser: any; // ToDo: loggedUser Type
   } & Body;
   query: {
-    loggedUser: string;
-  } & Query;
-};
+    loggedUser: string; // ToDo: loggedUser Type
+  } & Query &
+    Request["query"];
+} & Request;

--- a/app/src/types/koa-request.ts
+++ b/app/src/types/koa-request.ts
@@ -1,0 +1,10 @@
+import { Request } from "koa";
+
+export type TKoaRequest<Body = object, Query extends Request["query"]> = {
+  body: {
+    loggedUser: any;
+  } & Body;
+  query: {
+    loggedUser: string;
+  } & Query;
+};


### PR DESCRIPTION
Added a custom koa request type `TKoaRequest`

This can be used to strongly type the request object for each middleware route.

It can be passed two generics, first is the `Body` generic which will expect a DTO which represents the valid body request from the user. For example:
```typescript
// Body request
{
   role: `manager`
}
```
```typescript
type DTORole {
    role: string;
}
```
```typescript
const request = TKoaRequest<DTORole>ctx.request;

request.body.role // string
request.body.status // error: body does not include type 'status'
```

The koa request type also excepts the Query object which also you to strong type query params. For example \
`...?filter=type1`
```typescript
type TFilterQuery {
    filter: "type1" | "type2";
}
```
```typescript
const request = TKoaRequest<DTORole, TFilterQuery>ctx.request;

request.query.filter // "type1" | "type2"
```

The koa request type also adds the logged in user state to the body or query. Which is added in `app/src/services/LoggedInUserService.js` So:
```typescript
const request = TKoaRequest<DTORole>ctx.request;

request.body.loggedUser // { id: string; email: string; } - for POST, PATCH, PUT requests
request.query.loggedUser // string - for GET and DELETE requests
```