### PR TITLE
High: staging urls updated for the dev environment (tiny)

### DIFF
--- a/terraform/vars/terraform-dev.tfvars
+++ b/terraform/vars/terraform-dev.tfvars
@@ -9,7 +9,7 @@ auto_scaling_max_capacity = 5
 JWT_SECRET        = "@@JWT_SECRET@@"
 redis_queue_name  = "mail"
 APP_URL           = "https://gfw-web-dev.cube-cdn.com"
-USERS_API_URL     = "https://gfw-staging.globalforestwatch.org/v1"
+USERS_API_URL     = "https://staging-api.resourcewatch.org/v1"
 CONTROL_TOWER_URL = "https://staging-api.resourcewatch.org"
 
 healthcheck_path = "/v1/fw_teams/healthcheck"


### PR DESCRIPTION
`https://gfw-staging.globalforestwatch.org` has gone down, needs to be replaced with `https://staging-api.resourcewatch.org`