### PR TITLE
Normal: current env stored in the URL (small)

### DIFF
--- a/js/changeEnvironment.js
+++ b/js/changeEnvironment.js
@@ -1,16 +1,20 @@
 (doc => {
   const DOCS_SELECTOR = "#docs";
   const RAW_LINK_SELECTOR  = "#view-raw";
+  const ENV_PARAM_KEY = "env";
   const ENV = [
     {
+      value: "production",
       selector: "#switch-prod",
       docsURL: "https://raw.githubusercontent.com/wri/fw_teams/production/docs/fw_teams.yaml"
     },
     {
+      value: "staging",
       selector: "#switch-staging",
       docsURL: "https://raw.githubusercontent.com/wri/fw_teams/staging/docs/fw_teams.yaml"
     },
     {
+      value: "dev",
       selector: "#switch-dev",
       docsURL: "https://raw.githubusercontent.com/wri/fw_teams/dev/docs/fw_teams.yaml"
     }
@@ -25,12 +29,19 @@
     activeSwitch.classList.add("active");
   };
 
+  const updateEnvParam = value => {
+    let url = new URL(document.location);
+    url.searchParams.set(ENV_PARAM_KEY, value);
+    window.history.pushState(null, '', url.toString());
+  }
+
   const switchDocs = async env => {
     const docs = doc.querySelector(DOCS_SELECTOR);
     activateSwitch(env.selector);
     docs.apiDescriptionDocument = "";
     docs.apiDescriptionDocument = await fetch(env.docsURL).then(res => res.text());
     viewRawLink.href = env.docsURL;
+    updateEnvParam(env.value);
   };
 
   const init = () => {
@@ -44,8 +55,15 @@
       });
     });
 
-    const firstEnv = [...ENV].shift();
-    switchDocs(firstEnv);
+    // Find the current Env to load based on the URL param
+    // If not found then 'production' is set as the environment
+    let params = (new URL(document.location)).searchParams;
+    let currentEnv = [...ENV].shift();
+    if (params.has(ENV_PARAM_KEY) && ENV.find(env => env.value === params.get(ENV_PARAM_KEY))) {
+      currentEnv = ENV.find(env => env.value === params.get(ENV_PARAM_KEY));
+    }
+
+    switchDocs(currentEnv);
   };
 
   doc.addEventListener("DOMContentLoaded", init);


### PR DESCRIPTION
Docs page now stores the selected environment in the URL params. This means the url can be copied and referenced in slack messages correctly

https://user-images.githubusercontent.com/59919005/175033551-b866d821-9f4f-4a8c-9872-2677dd92c287.mov


